### PR TITLE
waypoints are shown only on first loading of track

### DIFF
--- a/src/mapbox.js
+++ b/src/mapbox.js
@@ -88,6 +88,7 @@ class Mapbox {
     this.updateTrack(this._tracks.get("route"));
 
     this.addTrack(new POIs("waypoints", trackutils.waypoints(geojson)));
+    this.updateTrack(this._tracks.get("waypoints"));
 
     [
       this._details.ascent,


### PR DESCRIPTION
I just came across an issue with waypoints when repeatedly loading tracks. It is pretty simple to reproduce:

1. go to page and load example - the sample waypoint is shown
1. clear track
1. load example again - the sample waypoint is not shown

For me this small change fixes the issue.